### PR TITLE
Feature/add dac gain mode

### DIFF
--- a/ADCDACPi/ABE_ADCDACPi.py
+++ b/ADCDACPi/ABE_ADCDACPi.py
@@ -116,7 +116,7 @@ class ADCDACPi:
         """
         if ((channel > 2) or (channel < 1)):
             print 'DAC channel needs to be 1 or 2'
-        if (voltage >= 0.0) and (voltage < 2.048):
+        if (voltage >= 0.0) and (voltage < self.__adcrefvoltage):
             rawval = (voltage / 2.048) * 4096 / self.gain
             self.set_dac_raw(channel, int(rawval))
         return

--- a/ADCDACPi/ABE_ADCDACPi.py
+++ b/ADCDACPi/ABE_ADCDACPi.py
@@ -2,17 +2,48 @@
 
 import RPi.GPIO as GPIO
 import spidev
+import ctypes
 
 """
 ================================================
 ABElectronics ADCDAC Pi Analogue to Digital / Digital to Analogue Converter
 Version 1.0 Created 16/05/2014
 Version 1.1 16/11/2014 updated code and functions to PEP8 format
+Version 1.2 5/9/2015 Added controllable gain factor
 ================================================
 
 Based on the Microchip MCP3202 and MCP4822
 """
 
+class Dac_bits(ctypes.LittleEndianStructure):
+    """Class to define the DAC command register bitfields.
+
+    See Microchip mcp4822 datasheet for more information
+    """
+    _fields_ = [
+                   ("data", ctypes.c_uint16, 12), #Bits 0:11
+                   ("shutdown", ctypes.c_uint16, 1), #Bit 12
+                   ("gain", ctypes.c_uint16, 1), #Bit 13
+                   ("reserved1", ctypes.c_uint16, 1), #Bit 14
+                   ("channel", ctypes.c_uint16, 1) #Bit 15
+               ]
+
+    #GA field value lookup. <gainFactor>:<bitfield val>
+    __ga_field__ = {1:1, 2:0}
+    def gain_to_field_val(self, gainFactor):
+        """Returns bitfield value based on desired gain"""
+        return self.__ga_field__[gainFactor]
+
+class Dac_register(ctypes.Union):
+    """Union to represent the DAC's command register
+
+    See Microchip mcp4822 datasheet for more information
+    """
+    _fields_ = [
+                   ("bits", Dac_bits),
+                   ("bytes", ctypes.c_uint8 * 2),
+                   ("reg", ctypes.c_uint16)
+               ]
 
 class ADCDACPi:
 
@@ -29,12 +60,26 @@ class ADCDACPi:
     spiDAC.max_speed_hz = (4000000)
 
     # public methods
+    def __init__(self, gainFactor = 1):
+        """Class Constructor
+
+        gainFactor -- Set the DAC's gain factor. The value should
+           be 1 or 2.  Gain factor is used to determine output voltage
+           from the formula: Vout = G * Vref * D/4096
+           Where G is gain factor, Vref (for this chip) is 2.048 and
+           D is the 12-bit digital value
+        """
+        if (gainFactor != 1) and (gainFactor != 2):
+            print 'Invalid gain factor. Must be 1 or 2'
+            self.gain = 1
+        else:
+            self.gain = gainFactor
 
     def read_adc_voltage(self, channel):
         """
-         Read the voltage from the selected channel on the ADC
+        Read the voltage from the selected channel on the ADC
          Channel = 1 or 2
-         """
+        """
         if ((channel > 2) or (channel < 1)):
             print 'ADC channel needs to be 1 or 2'
         raw = self.read_adc_raw(channel)
@@ -72,7 +117,7 @@ class ADCDACPi:
         if ((channel > 2) or (channel < 1)):
             print 'DAC channel needs to be 1 or 2'
         if (voltage >= 0.0) and (voltage < 2.048):
-            rawval = (voltage / 2.048) * 4096
+            rawval = (voltage / 2.048) * 4096 / self.gain
             self.set_dac_raw(channel, int(rawval))
         return
 
@@ -82,10 +127,16 @@ class ADCDACPi:
         Channel = 1 or 2
         Value between 0 and 4095
         """
-        lowByte = value & 0xff
-        highByte = (
-            (value >> 8) & 0xff) | (
-            channel -
-            1) << 7 | 0x1 << 5 | 1 << 4
-        self.spiDAC.xfer2([highByte, lowByte])
+        reg = Dac_register()
+
+        #Configurable fields
+        reg.bits.data = value
+        reg.bits.channel = channel - 1
+        reg.bits.gain = reg.bits.gain_to_field_val(self.gain)
+
+        #Fixed fields:
+        reg.bits.shutdown = 1 #Active low
+
+        #Write to device
+        self.spiDAC.xfer2( [ reg.bytes[1], reg.bytes[0] ])
         return

--- a/ADCDACPi/ABE_ADCDACPi.py
+++ b/ADCDACPi/ABE_ADCDACPi.py
@@ -59,6 +59,13 @@ class ADCDACPi:
     spiDAC.open(0, 1)
     spiDAC.max_speed_hz = (4000000)
 
+    #Max DAC output voltage. Depends on gain factor
+    #The following table is in the form <gain factor>:<max voltage>
+    __dacMaxOutput__ = {
+                            1:2.048, #This is Vref
+                            2:3.3 #This is Vdd for ABE ADCDACPi board
+                       }
+
     # public methods
     def __init__(self, gainFactor = 1):
         """Class Constructor
@@ -74,6 +81,8 @@ class ADCDACPi:
             self.gain = 1
         else:
             self.gain = gainFactor
+
+            self.maxDacVoltage = self.__dacMaxOutput__[self.gain]
 
     def read_adc_voltage(self, channel):
         """
@@ -116,9 +125,11 @@ class ADCDACPi:
         """
         if ((channel > 2) or (channel < 1)):
             print 'DAC channel needs to be 1 or 2'
-        if (voltage >= 0.0) and (voltage < self.__adcrefvoltage):
+        if (voltage >= 0.0) and (voltage < self.maxDacVoltage):
             rawval = (voltage / 2.048) * 4096 / self.gain
             self.set_dac_raw(channel, int(rawval))
+        else:
+            print "Invalid DAC Vout value %f. Must be between 0 and %f (non-inclusive) " % (voltage, self.maxDacVoltage)
         return
 
     def set_dac_raw(self, channel, value):


### PR DESCRIPTION
I noticed that the code was written to limit max voltage out of the DAC to the internal Vref (2.048 V).  The DAC data sheet explains that the output voltage may exceed the Vref through use of the gain bit (GA) in the DAC control word.  With 2x gain set, the DAC's output is ultimately limited by Vdd, which in the case of the ADCDACPi board is 3.3V.

This pull request adds support for configurable DAC gain value in order to achieve output voltage of greater than Vref (up to 3.3 V).  Additionally, I changed the bounds checking code to appropriately limit the max voltage depending on the gain factor being used.

I casually tested these changes using my own test app.  I didn't run through the provided demo code.

Thanks for looking.