### PR TITLE
Raise exception if conversion times out

### DIFF
--- a/ADCDifferentialPi/ADCDifferentialPi.py
+++ b/ADCDifferentialPi/ADCDifferentialPi.py
@@ -176,8 +176,7 @@ class ADCDifferentialPi:
             seconds_per_sample = 1 / 60
         elif self.__bitrate == 12:
             seconds_per_sample = 1 / 240
-        start_time = time.time()
-        timeout_time = start_time + 4 * seconds_per_sample
+        timeout_time = time.time() + 4 * seconds_per_sample
 
         # keep reading the adc data until the conversion result is ready
         while True:

--- a/ADCDifferentialPi/ADCDifferentialPi.py
+++ b/ADCDifferentialPi/ADCDifferentialPi.py
@@ -13,6 +13,7 @@ except ImportError:
     raise ImportError("python-smbus not found")
 import re
 import platform
+import time
 
 
 class ADCDifferentialPi:
@@ -165,6 +166,19 @@ class ADCDifferentialPi:
             config = config | (1 << 7)
             self.__bus.write_byte(address, config)
             config = config & ~(1 << 7)  # reset the ready bit to 0
+
+        # determine a reasonable amount of time to wait for a conversion
+        if self.__bitrate == 18:
+            seconds_per_sample = 1 / 3.75
+        elif self.__bitrate == 16:
+            seconds_per_sample = 1 / 15
+        elif self.__bitrate == 14:
+            seconds_per_sample = 1 / 60
+        elif self.__bitrate == 12:
+            seconds_per_sample = 1 / 240
+        start_time = time.time()
+        timeout_time = start_time + 4 * seconds_per_sample
+
         # keep reading the adc data until the conversion result is ready
         while True:
             __adcreading = self.__bus.read_i2c_block_data(address, config, 4)
@@ -180,6 +194,9 @@ class ADCDifferentialPi:
             # check if bit 7 of the command byte is 0.
             if(cmdbyte & (1 << 7)) == 0:
                 break
+            elif time.time() > timeout_time:
+                msg = 'read_raw: channel %i conversion timed out' % channel
+                raise TimeoutError(msg)
 
         self.__signbit = False
         raw = 0

--- a/ADCPi/ADCPi.py
+++ b/ADCPi/ADCPi.py
@@ -175,8 +175,7 @@ class ADCPi:
             seconds_per_sample = 1 / 60
         elif self.__bitrate == 12:
             seconds_per_sample = 1 / 240
-        start_time = time.time()
-        timeout_time = start_time + 4 * seconds_per_sample
+        timeout_time = time.time() + 4 * seconds_per_sample
 
         # keep reading the adc data until the conversion result is ready
         while True:

--- a/ADCPi/ADCPi.py
+++ b/ADCPi/ADCPi.py
@@ -13,6 +13,7 @@ except ImportError:
     raise ImportError("python-smbus not found")
 import re
 import platform
+import time
 
 
 class ADCPi:
@@ -164,6 +165,19 @@ class ADCPi:
             config = config | (1 << 7)
             self.__bus.write_byte(address, config)
             config = config & ~(1 << 7)  # reset the ready bit to 0
+
+        # determine a reasonable amount of time to wait for a conversion
+        if self.__bitrate == 18:
+            seconds_per_sample = 1 / 3.75
+        elif self.__bitrate == 16:
+            seconds_per_sample = 1 / 15
+        elif self.__bitrate == 14:
+            seconds_per_sample = 1 / 60
+        elif self.__bitrate == 12:
+            seconds_per_sample = 1 / 240
+        start_time = time.time()
+        timeout_time = start_time + 4 * seconds_per_sample
+
         # keep reading the adc data until the conversion result is ready
         while True:
             __adcreading = self.__bus.read_i2c_block_data(address, config, 4)
@@ -179,6 +193,9 @@ class ADCPi:
             # check if bit 7 of the command byte is 0.
             if(cmdbyte & (1 << 7)) == 0:
                 break
+            elif time.time() > timeout_time:
+                msg = 'read_raw: channel %i conversion timed out' % channel
+                raise TimeoutError(msg)
 
         self.__signbit = False
         raw = 0


### PR DESCRIPTION
Recently, one of the MCP3424 chips on my ADC Differential Pi suddenly stopped reporting measurements.  I ran `i2cdetect`, and, although it still appears on the I2C bus, it no longer sets the ready bit when a conversion request is sent.  Instead, the call to `read_i2c_block_data` for channel 5 continuously returns `[0, 0, 0, 140]`.  This caused the ADCDifferentialPi library to never return from `read_raw`.  This was a little difficult to track down because no error was being reported by the library.

With this change, an exception is raised if the ADC doesn’t set the ready bit within a reasonable amount of time.