### PR TITLE
Check for invalid channels at lower bound

### DIFF
--- a/ADCDifferentialPi/ADCDifferentialPi.py
+++ b/ADCDifferentialPi/ADCDifferentialPi.py
@@ -153,7 +153,7 @@ class ADCDifferentialPi:
 
         # get the config and i2c address for the selected channel
         self.__setchannel(channel)
-        if channel < 5:
+        if channel > 0 and channel < 5:
             config = self.__adc1_conf
             address = self.__adc1_address
         elif channel < 9:

--- a/ADCPi/ADCPi.py
+++ b/ADCPi/ADCPi.py
@@ -153,7 +153,7 @@ class ADCPi:
 
         # get the config and i2c address for the selected channel
         self.__setchannel(channel)
-        if channel < 5:
+        if channel > 0 and channel < 5:
             config = self.__adc1_conf
             address = self.__adc1_address
         elif channel < 9:


### PR DESCRIPTION
With this change, an error will be thrown if a channel numbered 0 or lower is specified.