### PR TITLE
Update ADCDifferentialPi.py

### DIFF
--- a/ADCDifferentialPi/ADCDifferentialPi.py
+++ b/ADCDifferentialPi/ADCDifferentialPi.py
@@ -254,7 +254,7 @@ class ADCDifferentialPi(object):
             seconds_per_sample = 0.01666
         elif self.__bitrate == 12:
             seconds_per_sample = 0.00416
-        timeout_time = time.time() + (100 * seconds_per_sample)
+        timeout_time = time.monotonic() + (100 * seconds_per_sample)
 
         # keep reading the ADC data until the conversion result is ready
         while True:
@@ -271,7 +271,7 @@ class ADCDifferentialPi(object):
             # check if bit 7 of the command byte is 0.
             if(cmdbyte & (1 << 7)) == 0:
                 break
-            elif time.time() > timeout_time:
+            elif time.time.monotonic() > timeout_time:
                 msg = 'read_raw: channel %i conversion timed out' % channel
                 raise TimeoutError(msg)
             else:


### PR DESCRIPTION
time.time() updates after network connection after boot. This will correct the pi's time by the time it took to boot roughly (There is no RTC). Monotonic does not need to do this https://docs.python.org/3/library/time.html#time.monotonic